### PR TITLE
Feature: Build OCI compliant container images in Github Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,6 +49,9 @@ jobs:
             # set latest tag for default branch
             type=raw,value=latest,suffix=-${{ matrix.arch.label }},enable={{is_default_branch}}
             type=sha,format=short,suffix=-${{ matrix.arch.label }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
       
       - name: Login to GHCI
         uses: docker/login-action@v3
@@ -61,6 +64,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
+          builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
           platforms: ${{ matrix.arch.name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,7 +83,7 @@ jobs:
   # of the container - in effect producing a multi-arch manifest
   build-release-bundle-manifest:
     needs:
-      - cri
+      - build-cri
     runs-on: ubuntu-latest
     # Only run if this commit references the default branch.
     if: ${{ always() && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,8 @@ on:
     branches: [main]
 
 env:
-  GHCR_REPO: ghcr.io/${{ github.repository }}
+  # {{ github.repository }} cannot be used here as the repository name contains upper case characters.
+  GHCR_REPO: ghcr.io/${{ github.repository_owner }}/yabinpp$
 
 jobs:
   build-cri:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   # {{ github.repository }} cannot be used here as the repository name contains upper case characters.
-  GHCR_REPO: ghcr.io/${{ github.repository_owner }}/yabinpp$
+  GHCR_REPO: ghcr.io/${{ github.repository_owner }}/yabinpp
 
 jobs:
   build-cri:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,110 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  GHCR_REPO: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-cri:
+    strategy:
+      matrix:
+        arch: 
+          - os: ubuntu-24.04
+            name: linux/amd64 
+            label: linux-amd64
+          - os: ubuntu-24.04-arm
+            name: linux/arm64
+            label: linux-arm64
+    runs-on: ${{ matrix.arch.os }}
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+
+      - name: Generate CRI metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.GHCR_REPO }}
+          labels: |
+            org.opencontainers.image.title=YABinPP
+            org.opencontainers.image.description=YABinPP (YABin Plus Plus) is a fork of YABin, a simple yet feature-rich pastebin.
+            org.opencontainers.image.url=https://github.com/iidgg/YABinPP
+            org.opencontainers.image.source=https://github.com/iidgg/YABinPP
+            org.opencontainers.image.vendor=iidgg
+          tags: |
+            # set latest tag for default branch
+            type=raw,value=latest,suffix=-${{ matrix.arch.label }},enable={{is_default_branch}}
+            type=sha,format=short,suffix=-${{ matrix.arch.label }}
+      
+      - name: Login to GHCI
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.arch.name }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Provenance must be off for the later manifest generation stage.
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.GHCR_REPO }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: ${{ github.event_name != 'pull_request' }}
+  
+  # build-release-bundle-manifest produces a container bundle manifest that points to both the amd64 and arm64 versions
+  # of the container - in effect producing a multi-arch manifest
+  build-release-bundle-manifest:
+    needs:
+      - cri
+    runs-on: ubuntu-latest
+    # Only run if this commit references the default branch.
+    if: ${{ always() && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
+    strategy:
+      matrix:
+        # Matrixed to provide for using other container stores (e.g docker) later down the line.
+        container_store:
+          - ghcr
+
+    steps:
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest (GHCR)
+        uses: Noelware/docker-manifest-action@0.4.2
+        if: matrix.container_store == 'ghcr'
+        with:
+          inputs: ${{env.GHCR_REPO}}:latest
+          images: ${{env.GHCR_REPO}}:latest-linux-amd64,${{env.GHCR_REPO}}:latest-linux-arm64
+          push: true

--- a/.github/workflows/codequality.yaml
+++ b/.github/workflows/codequality.yaml
@@ -1,9 +1,13 @@
-name: Continuous Integration
+name: Code Quality
 
 on:
   pull_request:
   push:
     branches: [main]
+
+env:
+  GHCR_REPO: ghcr.io/${{ github.repository }}
+
 
 jobs:
   prettier:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM --platform=$BUILDPLATFORM node:18-alpine AS builder
 
 WORKDIR /app
 
+RUN apk add --no-cache openssl
+
 COPY package.json yarn.lock ./
 COPY src/lib/server/prisma/ src/lib/server/prisma/
 
@@ -12,11 +14,11 @@ COPY . .
 RUN npm run build
 RUN npm prune --production
 
-FROM node:18-alpine
+FROM --platform=$BUILDPLATFORM node:18-alpine
 
 WORKDIR /app
 
-RUN npm install -g prisma pm2
+RUN apk add --no-cache openssl && npm install -g prisma pm2
 
 COPY scripts/ scripts/
 COPY package.json yarn.lock process.yml ./


### PR DESCRIPTION
This PR adds an Actions workflow for building Docker / OCI images and uploading them to the project's GHCI / packages.

By default, builds will happen for all branches (for CI), but will only be published for pushes to the default branch - should be trivial to change this to also push branches.

There are also some minor tweaks to the Dockerfile to get it building again.

It also moves the present linting workflow to a separate, new workflow to keep things tidy.